### PR TITLE
Added AlpineLinux

### DIFF
--- a/distributions/AlpineLinux.sh
+++ b/distributions/AlpineLinux.sh
@@ -1,0 +1,83 @@
+ERROR_EDGE="electrumX can currently be installed only on the edge Version of Alpine Linux"
+grep -q -F "/edge/main" /etc/apk/repositories > /dev/null || _error "${ERROR_EDGE}"
+grep -q -F "/edge/community" /etc/apk/repositories > /dev/null || _error "${ERROR_EDGE}"
+
+. distributions/base.sh
+
+APK="apk --no-cache"
+
+function install_script_dependencies {
+	REPO="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
+	grep -q -F "${REPO}" /etc/apk/repositories || echo "${REPO}" >> /etc/apk/repositories
+	apk update
+	$APK add leveldb
+	$APK add --virtual electrumX-dep openssl wget gcc g++ leveldb-dev
+}
+
+function add_user {
+	adduser -D electrumx
+	id -u electrumx || _error "Could not add user account" 1
+}
+
+function install_python36 {
+	$APK add python3
+	$APK add --virtual electrumX-python python3-dev
+	python3 -m pip install plyvel || _error "Could not install plyvel" 1
+	ln -s $(which python3.6) /usr/local/bin/python3
+}
+
+function install_git {
+	$APK add --virtual electrumX-git git
+}
+
+function install_rocksdb {
+	$APK add rocksdb
+	$APK add --virtual electrumX-db rocksdb-dev
+}
+
+function install_leveldb {
+	$APK add leveldb
+}
+
+function install_init {
+	# init is not required. Alpine is used for containers running the program directly
+	:
+}
+
+function generate_cert {
+	if ! which openssl > /dev/null 2>&1; then
+		_info "OpenSSL not found. Skipping certificates.."
+		return
+	fi
+	_DIR=$(pwd)
+	mkdir -p /etc/electrumx/
+	cd /etc/electrumx
+	# openssl default configuration is incomplet under alpine.
+	# Hence adding this configruation from archlinux to allow certificat creation
+	# https://www.archlinux.org/packages/core/x86_64/openssl/
+	echo "[ req ]
+distinguished_name	= req_distinguished_name
+
+[ req_distinguished_name ]
+countryName_default		= AU
+stateOrProvinceName_default	= Some-State
+0.organizationName_default	= Internet Widgits Pty Ltd" > openssl.cnf
+	openssl genrsa -des3 -passout pass:xxxx -out server.pass.key 2048
+	openssl rsa -passin pass:xxxx -in server.pass.key -out server.key
+	rm server.pass.key
+	openssl req -new -key server.key -batch -out server.csr
+	openssl x509 -req -days 1825 -in server.csr -signkey server.key -out server.crt
+	rm server.csr
+	chown electrumx:electrumx /etc/electrumx -R
+	chmod 600 /etc/electrumx/server*
+	cd $_DIR
+	echo -e "\nSSL_CERTFILE=/etc/electrumx/server.crt" >> /etc/electrumx.conf
+	echo "SSL_KEYFILE=/etc/electrumx/server.key" >> /etc/electrumx.conf
+	echo "TCP_PORT=50001" >> /etc/electrumx.conf
+	echo "SSL_PORT=50002" >> /etc/electrumx.conf
+	echo -e "# Listen on all interfaces:\nHOST=" >> /etc/electrumx.conf
+}
+
+function package_cleanup {
+	$APK del electrumX-dep electrumX-python electrumX-git electrumX-db
+}

--- a/install.sh
+++ b/install.sh
@@ -160,6 +160,11 @@ if [ $UPDATE_ONLY == 0 ]; then
 
 	_status "Generating TLS certificates"
 	generate_cert
+
+	if declare -f package_cleanup > /dev/null; then
+		_status "Cleaning up"
+		package_cleanup	
+	fi
 	_info "electrumx has been installed successfully. Edit /etc/electrumx.conf to configure it."
 else
 	_info "Updating electrumx"


### PR DESCRIPTION
This PR adds the support for Alpine Linux. Unfortunately currently only the edge version with the testing repository enabled can be used to install leveldb and rocksdb. 

The alternative would be to build both of them manually, which might increase the disk size the docker container will use afterwards.