### PR TITLE
Prefer Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,4 @@ env:
   - IMAGE="debian:8"
   - IMAGE="centos:7"
   - IMAGE="debian:9"
-  - IMAGE="alpine:edge"
   - IMAGE="ubuntu:18.04"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The following operating systems are officially supported and automatically being
 | Ubuntu 16.04   | [![ubuntu](https://badges.herokuapp.com/travis/bauerj/electrumx-installer?env=IMAGE=%22ubuntu:16.04%22&label=ubuntu:16.04)](https://travis-ci.org/bauerj/electrumx-installer/) |
 | CentOS 7       | [![centos](https://badges.herokuapp.com/travis/bauerj/electrumx-installer?env=IMAGE=%22centos:7%22&label=centos:7)](https://travis-ci.org/bauerj/electrumx-installer/) |
 | Debian Stretch | [![debian](https://badges.herokuapp.com/travis/bauerj/electrumx-installer?env=IMAGE=%22debian:9%22&label=debian:9)](https://travis-ci.org/bauerj/electrumx-installer/) |
-| Alpine Edge    | [![alpine](https://badges.herokuapp.com/travis/bauerj/electrumx-installer?env=IMAGE=%22alpine:edge%22&label=alpine:edge)](https://travis-ci.org/bauerj/electrumx-installer/) |
 
 
 If you prefer a different operating system that's not listed here, see

--- a/distributions/AlpineLinux.sh
+++ b/distributions/AlpineLinux.sh
@@ -10,8 +10,7 @@ function install_script_dependencies {
 	REPO="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
 	grep -q -F "${REPO}" /etc/apk/repositories || echo "${REPO}" >> /etc/apk/repositories
 	apk update
-	$APK add leveldb
-	$APK add --virtual electrumX-dep openssl wget gcc g++ leveldb-dev
+	$APK add --virtual electrumX-dep openssl wget gcc g++
 }
 
 function add_user {
@@ -19,15 +18,16 @@ function add_user {
 	id -u electrumx || _error "Could not add user account" 1
 }
 
-function install_python36 {
-	$APK add python3
-	$APK add --virtual electrumX-python python3-dev
-	python3 -m pip install plyvel || _error "Could not install plyvel" 1
-	ln -s $(which python3.6) /usr/local/bin/python3
+function install_python37 {
+	_error "Please install Python 3.7 manually"
 }
 
 function install_git {
 	$APK add --virtual electrumX-git git
+}
+
+function install_compiler {
+	$APK add gcc
 }
 
 function install_rocksdb {

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -6,7 +6,7 @@ if that file exists or the first word from `/etc/issue`.
 ## Implement the functions
 You need to define the following functions in your distribution file:
 - **add_user**: Create a user called `electrumx`
-- **install_python36**: Install Python 3.6. The first `python3` in `$PATH` should resolve to it.
+- **install_$python7**: Install Python 3.7. The first `$python` in `$PATH` should resolve to it.
 - **install_git**: Install git
 - **install_pyrocksdb**: Install pyrocksdb.
 - **install_leveldb**: Install libleveldb and its development headers

--- a/distributions/Ubuntu.sh
+++ b/distributions/Ubuntu.sh
@@ -13,18 +13,12 @@ fi
 
 has_rocksdb_binary=1
 
-function install_python36 {
+function install_python37 {
+	$APT install -y software-properties-common || _error "Could not install package" 5
+	add-apt-repository -y ppa:deadsnakes/ppa
 	$APT update
-	if [ "$VERSION_ID" == "16.04" ]; then
-	  $APT install -y software-properties-common || _error "Could not install package" 5
-	  add-apt-repository -y ppa:jonathonf/python-3.6
-	  $APT update
-	  packages="python3.6 python3.6-dev"
-	else
-	  packages="python3-pip python3.6-dev"
-	fi
-	$APT install -y $packages || _error "Could not install package python3.6" 1
-	ln -s $(which python3.6) /usr/local/bin/python3 > /dev/null
+	packages="python3.7 python3.7-dev python3.7-distutils"
+	$APT install -y $packages || _error "Could not install package python3.7" 1
 }
 
 function binary_install_rocksdb {

--- a/distributions/base-conda.sh
+++ b/distributions/base-conda.sh
@@ -7,12 +7,13 @@ function install_electrumx {
 	ln -s /opt/python/bin/electrumx* /usr/local/bin/
 }
 
-function install_python36 {
+function install_python37 {
 	if ! declare -f install_compiler > /dev/null; then
-		_error "install_compiler needs to be declared in order to use conda/install_python36" 3
+		_error "install_compiler needs to be declared in order to use conda/install_python37" 3
 	fi
 	install_compiler
 	wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/conda.sh || _error "while getting conda" 1
     bash /tmp/conda.sh -b -p /opt/python
-	ln -s /opt/python/bin/python3 /usr/local/bin/python3
+	/opt/python/bin/conda install python=3.7
+	ln -s /opt/python/bin/python3 /usr/local/bin/python3.7
 }

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,11 @@ NC='\033[0m' # No Color
 
 DB_DIR="/db"
 UPDATE_ONLY=0
+UPDATE_PYTHON=0
+VERBOSE=0
 USE_ROCKSDB=1
 ELECTRUMX_GIT_URL="https://github.com/kyuupichan/electrumx"
-ELECTRUMX_GIT_BRANCH="master"
+ELECTRUMX_GIT_BRANCH=""
 
 installer=$(realpath $0)
 
@@ -35,8 +37,10 @@ Usage: install.sh [OPTIONS]
 Install electrumx.
 
  -h --help                     Show this help
+ -v --verbose				   Enable verbose logging
  -d --dbdir dir                Set database directory (default: /db/)
  --update                      Update previously installed version
+ --update-python			   Install Python 3.7 and use with electrumx (doesn't remove system installation of Python 3)
  --leveldb                     Use LevelDB instead of RocksDB
 --electrumx-git-url url        Install ElectrumX from this URL instead
 --electrumx-git-branch branch  Install specific branch of ElectrumX repository
@@ -47,20 +51,26 @@ HELP
 	    DB_DIR="$2"
 	    shift # past argument
 	    ;;
+		-v|--verbose)
+		VERBOSE=1
+		;;
 	    --update)
 	    UPDATE_ONLY=1
+	    ;;
+		--update-python)
+	    UPDATE_PYTHON=1
 	    ;;
 	    --leveldb)
 	    USE_ROCKSDB=0
 	    ;;
-            --electrumx-git-url)
-            ELECTRUMX_GIT_URL="$2"
-            shift
-            ;;
-            --electrumx-git-branch)
-            ELECTRUMX_GIT_BRANCH="$2"
-            shift
-            ;;
+		--electrumx-git-url)
+		ELECTRUMX_GIT_URL="$2"
+		shift
+		;;
+		--electrumx-git-branch)
+		ELECTRUMX_GIT_BRANCH="$2"
+		shift
+		;;
 	    *)
 	    echo "WARNING: Unknown option $key" >&2
 	    exit 12
@@ -70,8 +80,12 @@ HELP
 done
 
 # redirect child output
-rm /tmp/electrumx-installer-$$.log > /dev/null 2>&1
+echo "" > /tmp/electrumx-installer-$$.log
 exec 3>&1 4>&2 2>/tmp/electrumx-installer-$$.log >&2
+
+if [ $VERBOSE == 1 ]; then
+	tail -f /tmp/electrumx-installer-$$.log &
+fi
 
 
 function _error {
@@ -144,22 +158,34 @@ if [ $UPDATE_ONLY == 0 ]; then
 	_status "Creating database directory in $DB_DIR"
 	create_db_dir $DB_DIR
 
-	if [[ $(python3 -V 2>&1) == *"Python 3.6"* ]] > /dev/null 2>&1; then
+	python=""
+
+	for _python in python3.7 python3; do
+		if which $_python; then
+		python=$_python
+		fi
+	done
+
+	if [[ $($python -V 2>&1) == *"Python 3.6"* ]] > /dev/null 2>&1; then
 		_info "Python 3.6 is already installed."
+	elif [[ $($python -V 2>&1) == *"Python 3.7"* ]] > /dev/null 2>&1; then
+		_info "Python 3.7 is already installed."
 	else
-		_status "Installing Python 3.6"
-		install_python36
+		_status "Installing Python 3.7"
+		python=python3.7
+		install_python37
+		if [[ $($python -V 2>&1) == *"Python 3.7"* ]] > /dev/null 2>&1; then
+			_info "Python 3.7 successfully installed"
+		else
+			_error "Unable to install Python 3.7" 4
+		fi
 	fi
-	if [[ $(python3 -V 2>&1) == *"Python 3.6"* ]] > /dev/null 2>&1; then
-		_info "Python 3.6 successfully installed"
-	else
-		_error "Unable to install Python 3.6" 4
-	fi
+	
 
 	_status "Installing git"
 	install_git
 
-	if ! python3 -m pip > /dev/null 2>&1; then
+	if ! $python -m pip > /dev/null 2>&1; then
 		_progress_total=$(( $_progress_total + 2 ))
 		_status "Installing pip"
 		install_pip
@@ -173,8 +199,8 @@ if [ $UPDATE_ONLY == 0 ]; then
         else
             install_rocksdb
         fi
-                if [ -z $newer_rocksdb ]; then
-			 _status "Installing pyrocksdb"
+            if [ -z $newer_rocksdb ]; then
+			    _status "Installing pyrocksdb"
 			install_pyrocksdb
 		else
 			 _status "Installing python_rocksdb"
@@ -215,8 +241,8 @@ if [ $UPDATE_ONLY == 0 ]; then
 else
 	_info "Updating electrumx"
 	i=0
-	while python3 -m pip show electrumx; do
-	    python3 -m pip uninstall -y electrumx || true
+	while $python -m pip show electrumx; do
+	    $python -m pip uninstall -y electrumx || true
 	    ((i++))
 	    if "$i" -gt 5; then
 	        break
@@ -228,5 +254,5 @@ else
 		systemctl daemon-reload
 	fi
 	install_electrumx
-        _info "Installed $(python3 -m pip freeze | grep -i electrumx)"
+        _info "Installed $($python -m pip freeze | grep -i electrumx)"
 fi


### PR DESCRIPTION
This is in preparation for an electrumx update that raises the minimum supported Python version to 3.7.

- It now installs Python 3.7 if no Python 3 is there
- It will also install Python 3.7 if `--update-python` is used
- For multiple installed Pythons, it will always prefer to run electrumx with 3.7
- Alpine support is dropped for now since it doesn't even support Python 3.7 yet