### PR TITLE
Fix install path when package is downloaded as zip

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,13 +6,14 @@ if [ -d ~/.electrumx-installer ]; then
 fi
 if which git > /dev/null 2>&1; then
     git clone https://github.com/bauerj/electrumx-installer ~/.electrumx-installer
+    cd ~/.electrumx-installer/
 else
     which wget > /dev/null 2>&1 && which unzip > /dev/null 2>&1 || { echo "Please install git or wget and unzip" && exit 1 ; }
     wget https://github.com/bauerj/electrumx-installer/archive/master.zip -O /tmp/electrumx-master.zip
     unzip /tmp/electrumx-master.zip -d ~/.electrumx-installer
     rm /tmp/electrumx-master.zip
+    cd ~/.electrumx-installer/electrumx-installer-master/ 
 fi
-cd ~/.electrumx-installer/
 if [[ $EUID -ne 0 ]]; then
     which sudo > /dev/null 2>&1 || { echo "You need to run this script as root" && exit 1 ; }
     sudo -H ./install.sh "$@"


### PR DESCRIPTION
When the package is downloaded as zip the installation files are found in
~/.electrumx-installer/electrumx-installer-master/