### PR TITLE
Fixed bug with --electrumx-git-branch

### DIFF
--- a/distributions/base.sh
+++ b/distributions/base.sh
@@ -13,7 +13,7 @@ function install_electrumx {
 	rm -rf "/tmp/electrumx/"
 	git clone $ELECTRUMX_GIT_URL /tmp/electrumx
 	cd /tmp/electrumx
-	if [ -z "$ELECTRUMX_GIT_BRANCH" ]; then
+	if [ -n "$ELECTRUMX_GIT_BRANCH" ]; then
 		git checkout $ELECTRUMX_GIT_BRANCH
 	else
 		git checkout $(git describe --tags)


### PR DESCRIPTION
The `--electrumx-git-branch` option didn't work due to a small bug in `distributions/base.sh`.