### PR TITLE
Use SERVICES env var in the conf file

### DIFF
--- a/distributions/AlpineLinux.sh
+++ b/distributions/AlpineLinux.sh
@@ -73,9 +73,7 @@ stateOrProvinceName_default	= Some-State
 	cd $_DIR
 	echo -e "\nSSL_CERTFILE=/etc/electrumx/server.crt" >> /etc/electrumx.conf
 	echo "SSL_KEYFILE=/etc/electrumx/server.key" >> /etc/electrumx.conf
-	echo "TCP_PORT=50001" >> /etc/electrumx.conf
-	echo "SSL_PORT=50002" >> /etc/electrumx.conf
-	echo -e "# Listen on all interfaces:\nHOST=" >> /etc/electrumx.conf
+	echo "SERVICES=tcp://:50001,ssl://:50002,wss://:50004,rpc://" >> /etc/electrumx.conf
 }
 
 function package_cleanup {

--- a/distributions/base.sh
+++ b/distributions/base.sh
@@ -78,9 +78,7 @@ function generate_cert {
 	cd $_DIR
 	echo -e "\nSSL_CERTFILE=/etc/electrumx/server.crt" >> /etc/electrumx.conf
 	echo "SSL_KEYFILE=/etc/electrumx/server.key" >> /etc/electrumx.conf
-        echo "TCP_PORT=50001" >> /etc/electrumx.conf
-        echo "SSL_PORT=50002" >> /etc/electrumx.conf
-        echo -e "# Listen on all interfaces:\nHOST=" >> /etc/electrumx.conf
+    echo "SERVICES=tcp://:50001,ssl://:50002,wss://:50004,rpc://" >> /etc/electrumx.conf
 }
 
 function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }


### PR DESCRIPTION
Use `SERVICES` env var in the conf file as `TCP_PORT`, `SSL_PORT` and `HOST` are all deprecated and can no longer be used in "electrumx.conf" file.

Without this update, electrumx server refuses to start.

Reference:
https://electrumx.readthedocs.io/en/latest/environment.html#envvar-SERVICES